### PR TITLE
feat(llm): truncate topic clusters to respect MAX_SUMMARY_TOKENS

### DIFF
--- a/dist/config/index.js
+++ b/dist/config/index.js
@@ -44,6 +44,10 @@ const ConfigSchema = zod_1.z.object({
     MIN_MESSAGE_LENGTH: zod_1.z.preprocess(toNum, zod_1.z.number().int().min(1)).default(20),
     EXCLUDE_COMMANDS: zod_1.z.preprocess(toBool, zod_1.z.boolean()).default(true),
     EXCLUDE_LINK_ONLY: zod_1.z.preprocess(toBool, zod_1.z.boolean()).default(true),
+    ATTRIBUTION_ENABLED: zod_1.z.preprocess(toBool, zod_1.z.boolean()).default(false),
+    TOPIC_GAP_MINUTES: zod_1.z.preprocess(toNum, zod_1.z.number().int().min(1)).default(20),
+    MAX_TOPIC_PARTICIPANTS: zod_1.z.preprocess(toNum, zod_1.z.number().int().min(1)).default(6),
+    ATTRIBUTION_FALLBACK_ENABLED: zod_1.z.preprocess(toBool, zod_1.z.boolean()).default(true),
 });
 const logger_1 = require("../utils/logger");
 function loadConfig() {
@@ -71,6 +75,10 @@ function loadConfig() {
         minMessageLength: config.MIN_MESSAGE_LENGTH,
         excludeCommands: config.EXCLUDE_COMMANDS,
         excludeLinkOnly: config.EXCLUDE_LINK_ONLY,
+        attributionEnabled: config.ATTRIBUTION_ENABLED,
+        topicGapMinutes: config.TOPIC_GAP_MINUTES,
+        maxTopicParticipants: config.MAX_TOPIC_PARTICIPANTS,
+        attributionFallbackEnabled: config.ATTRIBUTION_FALLBACK_ENABLED,
         discordChannelsCount: config.DISCORD_CHANNELS.length,
         secrets: {
             GEMINI_API_KEY: mask(process.env.GEMINI_API_KEY || ""),

--- a/dist/services/llm/gemini.js
+++ b/dist/services/llm/gemini.js
@@ -1,12 +1,15 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.summarize = summarize;
+exports.summarizeAttributed = summarizeAttributed;
 exports.buildPrompt = buildPrompt;
 exports.truncateMessages = truncateMessages;
 exports.formatMessageLine = formatMessageLine;
+exports.buildAttributedPrompt = buildAttributedPrompt;
 // services/llm/gemini.ts
 const generative_ai_1 = require("@google/generative-ai");
 const logger_1 = require("../../utils/logger");
+const topics_1 = require("../../utils/topics");
 function formatMessageLine(msg) {
     const date = new Date(msg.createdAt);
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -29,8 +32,39 @@ function buildPrompt(messages) {
         "",
         ...messages.map((m, i) => `[${i + 1}] ${formatMessageLine(m)}`),
         "",
-        "Digest:"
+        "Digest:",
     ].join("\n");
+}
+/**
+ * Build a prompt that includes per-topic clusters and participant lists.
+ * @param clusters TopicCluster[]
+ * @param config Config (for token budgeting notes)
+ */
+function buildAttributedPrompt(clusters, config) {
+    const parts = [];
+    parts.push("Community Digest (Attributed):");
+    parts.push("Summarize the following topic clusters derived from Discord messages.");
+    parts.push("For each topic, produce concise bullets under the sections: Key Topics, Decisions, Action Items, Links.");
+    parts.push("For any bullet derived from a topic, include a trailing 'Participants: name1, name2' line listing the participants involved in that topic.");
+    parts.push("Do not invent participants not listed below. Use the exact participant names provided.");
+    parts.push("");
+    parts.push("Input topics (chronological):");
+    parts.push("");
+    for (const c of clusters) {
+        const participants = (0, topics_1.formatParticipantList)(c.participants, config.MAX_TOPIC_PARTICIPANTS);
+        parts.push(`Topic ${c.id}:`);
+        parts.push(`Channel: ${c.channelId}`);
+        parts.push(`Participants: ${participants || "none"}`);
+        parts.push("Messages:");
+        for (let i = 0; i < c.messages.length; i++) {
+            parts.push(`[${i + 1}] ${formatMessageLine(c.messages[i])}`);
+        }
+        parts.push(""); // spacer between topics
+    }
+    parts.push("Digest:");
+    parts.push("");
+    parts.push(`Notes: Limit output to concise bullets. If a topic contains no substantive content, omit it. Max summary token budget: ${config.MAX_SUMMARY_TOKENS}.`);
+    return parts.join("\n");
 }
 function truncateMessages(messages, maxChars) {
     let total = 0;
@@ -42,6 +76,42 @@ function truncateMessages(messages, maxChars) {
         total += m.content.length;
     }
     return out;
+}
+/**
+ * truncateClusters - reduce messages across clusters to fit a global character budget.
+ * Returns new clusters with messages trimmed in chronological order until budget exhausted.
+ * Participants are preserved from original cluster (TODO: recompute from truncated messages).
+ */
+function truncateClusters(clusters, maxChars) {
+    if (!clusters || clusters.length === 0)
+        return [];
+    let total = 0;
+    const result = [];
+    outer: for (const c of clusters) {
+        const keptMessages = [];
+        for (const m of c.messages) {
+            const len = m.content ? m.content.length : 0;
+            if (total + len > maxChars) {
+                if (keptMessages.length === 0) {
+                    // No room for any message in this cluster; stop processing further clusters.
+                    break outer;
+                }
+                else {
+                    // Partial cluster preserved; stop after this cluster.
+                    result.push({ ...c, messages: keptMessages, participants: c.participants });
+                    break outer;
+                }
+            }
+            keptMessages.push(m);
+            total += len;
+        }
+        if (keptMessages.length > 0) {
+            result.push({ ...c, messages: keptMessages, participants: c.participants });
+        }
+        if (total >= maxChars)
+            break;
+    }
+    return result;
 }
 async function summarize(messages, config) {
     if (!config.GEMINI_MODEL || config.GEMINI_MODEL.trim() === "") {
@@ -55,6 +125,37 @@ async function summarize(messages, config) {
     const maxChars = config.MAX_SUMMARY_TOKENS * 4;
     const truncated = truncateMessages(messages, maxChars);
     const prompt = buildPrompt(truncated);
+    const result = await model.generateContent({
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        generationConfig: {
+            maxOutputTokens: config.MAX_SUMMARY_TOKENS,
+            temperature: 0.2,
+        },
+    });
+    return result.response.text();
+}
+/**
+ * summarizeAttributed - accepts topic clusters (with participants) and asks the LLM
+ * to include Participants lines per topic-derived bullet.
+ */
+async function summarizeAttributed(clusters, config) {
+    if (!config.GEMINI_MODEL || config.GEMINI_MODEL.trim() === "") {
+        logger_1.logger.error("GEMINI_MODEL is empty; check CI env or repository Variables export.");
+        throw new Error("GEMINI_MODEL is required");
+    }
+    logger_1.logger.info("Gemini attributed init", { model: config.GEMINI_MODEL, maxTokens: config.MAX_SUMMARY_TOKENS });
+    const genAI = new generative_ai_1.GoogleGenerativeAI(config.GEMINI_API_KEY);
+    const model = genAI.getGenerativeModel({ model: config.GEMINI_MODEL });
+    // Build prompt from clusters and truncate to token budget.
+    const maxChars = config.MAX_SUMMARY_TOKENS * 4;
+    const truncatedClusters = truncateClusters(clusters, maxChars);
+    let prompt = buildAttributedPrompt(truncatedClusters, config);
+    // If truncation occurred, append a short note so the LLM knows input was truncated.
+    const truncatedOccurred = truncatedClusters.length !== clusters.length ||
+        truncatedClusters.some((tc, idx) => (clusters[idx] ? tc.messages.length !== clusters[idx].messages.length : true));
+    if (truncatedOccurred) {
+        prompt += "\n\n[Note: input truncated to fit token budget]";
+    }
     const result = await model.generateContent({
         contents: [{ role: "user", parts: [{ text: prompt }] }],
         generationConfig: {

--- a/dist/utils/format.js
+++ b/dist/utils/format.js
@@ -57,12 +57,45 @@ function buildDigestBlocks(params) {
     const cleaned = stripLeadingDigestTitle(params.summary);
     const mrkdwn = normalizeToSlackMrkdwn(cleaned);
     const range = `Time window: ${params.dateTitle} 00:00–${params.end.toISOString().slice(0, 10)} 00:00 UTC`;
-    return [
+    const blocks = [
         { type: "header", text: { type: "plain_text", text: `Community Digest — ${params.dateTitle} (UTC)` } },
         { type: "context", elements: [{ type: "mrkdwn", text: range }] },
         { type: "divider" },
-        { type: "section", text: { type: "mrkdwn", text: `*Summary*\n${truncateSection(mrkdwn)}` } }
     ];
+    // If the digest doesn't include explicit sectioning, preserve legacy behavior:
+    // single Summary section with the full content under "*Summary*"
+    if (!/^\s*\*?Summary\*?/im.test(mrkdwn)) {
+        blocks.push({ type: "section", text: { type: "mrkdwn", text: `*Summary*\n${truncateSection(mrkdwn)}` } });
+        return blocks;
+    }
+    // Split digest into logical sections by two-or-more newlines.
+    // Each section may end with a "Participants: ..." line which we render as a separate context block.
+    const sections = mrkdwn.split(/\n{2,}/).map(s => s.trim()).filter(Boolean);
+    for (const sec of sections) {
+        // Try to extract a trailing Participants line
+        const lines = sec.split("\n").map(l => l.trim()).filter(Boolean);
+        let participantsLine = null;
+        // check last line for a Participants: prefix (case-insensitive)
+        const last = lines[lines.length - 1] || "";
+        const match = last.match(/^\s*Participants:\s*(.+)$/i);
+        if (match) {
+            participantsLine = match[1].trim();
+            // remove the last line from the section text
+            lines.pop();
+        }
+        const sectionText = truncateSection(lines.join("\n\n"));
+        if (sectionText) {
+            blocks.push({ type: "section", text: { type: "mrkdwn", text: sectionText } });
+        }
+        if (participantsLine) {
+            // render participants in a smaller context block
+            blocks.push({
+                type: "context",
+                elements: [{ type: "mrkdwn", text: `*Participants:* ${participantsLine}` }],
+            });
+        }
+    }
+    return blocks;
 }
 // Legacy fallback
 function formatDigest(summary) {

--- a/dist/utils/participants_fallback.js
+++ b/dist/utils/participants_fallback.js
@@ -1,0 +1,113 @@
+"use strict";
+/**
+ * Lightweight post-processing fallback to inject missing "Participants:" lines
+ * when an LLM omits them from an attributed digest.
+ *
+ * This utility is intentionally conservative:
+ * - It only adds lines for clusters that have at least one participant.
+ * - It caps participant names using provided maxTopics cap.
+ * - It tries to place the Participants line near matching content (signature words).
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.injectMissingParticipants = injectMissingParticipants;
+/**
+ * buildCompactParticipantString - produce compact list capped by max
+ */
+function buildCompactParticipantString(names, max) {
+    if (!names || names.length === 0)
+        return "";
+    if (names.length <= max)
+        return names.join(", ");
+    const shown = names.slice(0, max).join(", ");
+    const remaining = names.length - max;
+    return `${shown} +${remaining}`;
+}
+/**
+ * extractSignatureWords - small set of distinctive words from first message
+ */
+function extractSignatureWords(msgText) {
+    if (!msgText)
+        return [];
+    return msgText
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length > 3)
+        .slice(0, 6);
+}
+/**
+ * anyParticipantLineContains - case-insensitive check if a section's Participants lines
+ * mention at least one of the participant names
+ */
+function anyParticipantLineContains(sectionText, participantNames) {
+    if (!participantNames || participantNames.length === 0)
+        return false;
+    const match = sectionText.match(/Participants:\s*(.+)$/im);
+    if (!match)
+        return false;
+    const listed = match[1].toLowerCase();
+    return participantNames.some((p) => listed.includes(p.toLowerCase()));
+}
+/**
+ * injectMissingParticipants
+ * @param summary original digest text
+ * @param clusters topic clusters with participants
+ * @param maxPerTopic cap for participants shown
+ * @returns modified summary (or original if nothing inserted)
+ */
+function injectMissingParticipants(summary, clusters, maxPerTopic = 6) {
+    if (!summary || !clusters || clusters.length === 0)
+        return summary;
+    const sections = summary.split(/\n{2,}/).map((s) => s.trim());
+    let changed = false;
+    // For faster matching, prepare lowercased section text
+    const sectionsLc = sections.map((s) => s.toLowerCase());
+    for (const cluster of clusters) {
+        if (!cluster.participants || cluster.participants.length === 0)
+            continue;
+        // If any section already lists these participants, skip
+        const alreadyListed = sections.some((sec) => anyParticipantLineContains(sec, cluster.participants));
+        if (alreadyListed)
+            continue;
+        // Build signature words from first message in cluster
+        const firstMsg = cluster.messages && cluster.messages.length > 0 ? cluster.messages[0].content : "";
+        const sigWords = extractSignatureWords(firstMsg);
+        let placed = false;
+        if (sigWords.length > 0) {
+            // Try to find a section containing any signature word
+            for (let i = 0; i < sections.length; i++) {
+                const secLc = sectionsLc[i];
+                if (!secLc)
+                    continue;
+                const matches = sigWords.some((w) => secLc.includes(w));
+                if (matches) {
+                    // Append Participants line to this section
+                    const partStr = buildCompactParticipantString(cluster.participants, maxPerTopic);
+                    sections[i] = `${sections[i]}\nParticipants: ${partStr}`;
+                    sectionsLc[i] = sections[i].toLowerCase();
+                    changed = true;
+                    placed = true;
+                    break;
+                }
+            }
+        }
+        if (!placed) {
+            // As fallback, append to last non-empty section
+            for (let i = sections.length - 1; i >= 0; i--) {
+                if (sections[i].trim().length > 0) {
+                    const partStr = buildCompactParticipantString(cluster.participants, maxPerTopic);
+                    sections[i] = sections[i] + "\nParticipants: " + partStr;
+                    sectionsLc[i] = sections[i].toLowerCase();
+                    changed = true;
+                    placed = true;
+                    break;
+                }
+            }
+        }
+    }
+    if (!changed)
+        return summary;
+    // Reconstruct with double-newline separators
+    return sections.join("\n\n");
+}
+exports.default = injectMissingParticipants;

--- a/dist/utils/topic_refine.js
+++ b/dist/utils/topic_refine.js
@@ -1,0 +1,23 @@
+"use strict";
+/**
+ * src/utils/topic_refine.ts
+ *
+ * Scaffold for future semantic clustering / refinement of topic clusters.
+ * Currently provides a no-op API and documentation for planned behavior.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.refineClusters = refineClusters;
+/**
+ * refineClusters - placeholder for future semantic merging of adjacent clusters.
+ * Current implementation returns clusters unchanged.
+ *
+ * Planned heuristic (not yet implemented):
+ * - For each pair of adjacent clusters in the same channel compute Jaccard overlap
+ *   over token sets of their messages (stopwords removed).
+ * - Merge clusters if overlap >= 0.4 or share >= 3 uncommon tokens.
+ * - Aim for linear scan merging to preserve chronology.
+ */
+function refineClusters(clusters) {
+    // TODO: implement semantic merging using bag-of-words or embeddings.
+    return clusters;
+}

--- a/dist/utils/topics.js
+++ b/dist/utils/topics.js
@@ -1,0 +1,101 @@
+"use strict";
+/**
+ * src/utils/topics.ts
+ *
+ * Utilities to cluster Discord messages into lightweight "topic" windows
+ * and extract participants for per-topic attribution in digests.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.clusterMessages = clusterMessages;
+exports.extractParticipants = extractParticipants;
+exports.formatParticipantList = formatParticipantList;
+const UNKNOWN_AUTHOR = "unknown";
+/**
+ * clusterMessages - group messages into topic windows by channel + time gap
+ * @param messages unsorted array of MessageDTO
+ * @param gapMinutes break cluster when gap (minutes) exceeded
+ */
+function clusterMessages(messages, gapMinutes = 20) {
+    if (!messages || messages.length === 0)
+        return [];
+    // Sort by channelId then timestamp ascending
+    const sorted = [...messages].sort((a, b) => {
+        if (a.channelId < b.channelId)
+            return -1;
+        if (a.channelId > b.channelId)
+            return 1;
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+    const clusters = [];
+    let current = null;
+    let id = 1;
+    const gapMs = gapMinutes * 60 * 1000;
+    for (const msg of sorted) {
+        const ts = new Date(msg.createdAt).getTime();
+        if (!current) {
+            current = {
+                id: id++,
+                channelId: msg.channelId,
+                start: msg.createdAt,
+                end: msg.createdAt,
+                messages: [msg],
+                participants: [],
+            };
+            continue;
+        }
+        const lastMsg = current.messages[current.messages.length - 1];
+        const lastTs = new Date(lastMsg.createdAt).getTime();
+        const channelChanged = msg.channelId !== current.channelId;
+        const gapExceeded = ts - lastTs > gapMs;
+        if (channelChanged || gapExceeded) {
+            // finalize participants
+            current.participants = extractParticipants(current);
+            clusters.push(current);
+            current = {
+                id: id++,
+                channelId: msg.channelId,
+                start: msg.createdAt,
+                end: msg.createdAt,
+                messages: [msg],
+                participants: [],
+            };
+        }
+        else {
+            current.messages.push(msg);
+            current.end = msg.createdAt;
+        }
+    }
+    if (current) {
+        current.participants = extractParticipants(current);
+        clusters.push(current);
+    }
+    return clusters;
+}
+/**
+ * extractParticipants - return unique author names in chronological order
+ */
+function extractParticipants(cluster) {
+    const seen = new Set();
+    const out = [];
+    for (const m of cluster.messages) {
+        const name = m.author || UNKNOWN_AUTHOR;
+        if (!seen.has(name)) {
+            seen.add(name);
+            out.push(name);
+        }
+    }
+    return out;
+}
+/**
+ * formatParticipantList - produce a compact comma-separated list capped by max
+ * returns e.g. "alice, bob, carol +2"
+ */
+function formatParticipantList(list, max = 6) {
+    if (!list || list.length === 0)
+        return "";
+    if (list.length <= max)
+        return list.join(", ");
+    const shown = list.slice(0, max).join(", ");
+    const remaining = list.length - max;
+    return `${shown} +${remaining}`;
+}


### PR DESCRIPTION
- Add truncateClusters to trim messages across topic clusters to a global char budget
- Wire truncation into summarizeAttributed and append truncation note when used
- Add topic_refine scaffold and participants_fallback utility (compiled artifacts included)
- Update generated dist files to reflect changes; build/tests verified