### PR TITLE
fix: config defaults survive empty-string env vars

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,55 +31,60 @@ const ConfigSchema = z.object({
   SLACK_CHANNEL_ID: z.preprocess(toStr, z.string()).optional(),
   GEMINI_API_KEY: z.preprocess(toStr, z.string()).optional(),
 
-  GEMINI_MODEL: z.preprocess(toStr, z.string()).default("gemini-3.6-flash"),
+  // Defaults live inside the preprocess so they apply when an env var is
+  // absent OR empty. In GitHub Actions an unset `${{ vars.X }}` interpolates
+  // to "" (present, not undefined); toStr/toNum/toBool normalize "" to
+  // undefined, and the inner .default() then fires. Placing .default() on the
+  // outer preprocess would be skipped for "" and cause validation to throw.
+  GEMINI_MODEL: z.preprocess(toStr, z.string().default("gemini-3.6-flash")),
 
   // Budget for the LLM response. Gemini 3.x reasoning tokens count against
   // this limit, so it must leave headroom beyond the visible summary text.
   MAX_SUMMARY_TOKENS: z.preprocess(
     toNum,
-    z.number().int().min(128)
-  ).default(4000),
+    z.number().int().min(128).default(4000)
+  ),
 
   // Ceiling on prompt content per conversation group. Bounds worst-case
   // API cost; well within the model's 1M-token context either way.
   MAX_INPUT_CHARS_PER_GROUP: z.preprocess(
     toNum,
-    z.number().int().min(1000)
-  ).default(100_000),
+    z.number().int().min(1000).default(100_000)
+  ),
 
   DRY_RUN: z.preprocess(
     toBool,
-    z.boolean()
-  ).default(true),
+    z.boolean().default(true)
+  ),
 
   DIGEST_WINDOW_HOURS: z.preprocess(
     toNum,
-    z.number().int().min(1)
-  ).default(24),
+    z.number().int().min(1).default(24)
+  ),
 
-  LOG_LEVEL: z.string().default("info"),
+  LOG_LEVEL: z.preprocess(toStr, z.string().default("info")),
 
   MIN_MESSAGE_LENGTH: z.preprocess(
     toNum,
-    z.number().int().min(1)
-  ).default(20),
+    z.number().int().min(1).default(20)
+  ),
 
   EXCLUDE_COMMANDS: z.preprocess(
     toBool,
-    z.boolean()
-  ).default(true),
+    z.boolean().default(true)
+  ),
 
   EXCLUDE_LINK_ONLY: z.preprocess(
     toBool,
-    z.boolean()
-  ).default(true),
+    z.boolean().default(true)
+  ),
 
 
 
 
   // Per-source enable flags (keep defaults but allow explicit unset)
-  ENABLE_DISCORD: z.preprocess(toBool, z.boolean()).optional().default(true),
-  ENABLE_DISCOURSE: z.preprocess(toBool, z.boolean()).optional().default(true),
+  ENABLE_DISCORD: z.preprocess(toBool, z.boolean().default(true)),
+  ENABLE_DISCOURSE: z.preprocess(toBool, z.boolean().default(true)),
 
 
   // Discourse-related optional settings

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -40,6 +40,37 @@ describe('Config Service', () => {
         expect(config.ENABLE_DISCOURSE).toBe(true);
     });
 
+    it('should fall back to defaults when env vars are empty strings', () => {
+        // GitHub Actions interpolates an unset `${{ vars.X }}` to "" (present,
+        // not undefined). Empty strings must resolve to the code defaults
+        // rather than failing validation — this was the prod digest crash.
+        process.env.GEMINI_MODEL = '';
+        process.env.MAX_SUMMARY_TOKENS = '';
+        process.env.MAX_INPUT_CHARS_PER_GROUP = '';
+        process.env.DRY_RUN = '';
+        process.env.DIGEST_WINDOW_HOURS = '';
+        process.env.LOG_LEVEL = '';
+        process.env.MIN_MESSAGE_LENGTH = '';
+        process.env.EXCLUDE_COMMANDS = '';
+        process.env.EXCLUDE_LINK_ONLY = '';
+        process.env.ENABLE_DISCORD = '';
+        process.env.ENABLE_DISCOURSE = '';
+
+        const config = loadConfig();
+
+        expect(config.GEMINI_MODEL).toBe('gemini-3.6-flash');
+        expect(config.MAX_SUMMARY_TOKENS).toBe(4000);
+        expect(config.MAX_INPUT_CHARS_PER_GROUP).toBe(100000);
+        expect(config.DRY_RUN).toBe(true);
+        expect(config.DIGEST_WINDOW_HOURS).toBe(24);
+        expect(config.LOG_LEVEL).toBe('info');
+        expect(config.MIN_MESSAGE_LENGTH).toBe(20);
+        expect(config.EXCLUDE_COMMANDS).toBe(true);
+        expect(config.EXCLUDE_LINK_ONLY).toBe(true);
+        expect(config.ENABLE_DISCORD).toBe(true);
+        expect(config.ENABLE_DISCOURSE).toBe(true);
+    });
+
     it('should override defaults with environment variables', () => {
         process.env.GEMINI_MODEL = 'gemini-pro';
         process.env.MAX_SUMMARY_TOKENS = '2000';


### PR DESCRIPTION
## Problem

The Daily Digest run on 2026-07-22 ([run 29922013684](https://github.com/alchemydc/synapse/actions/runs/29922013684)) failed at the **Run digest bot** step:

```
Invalid config: {"MAX_INPUT_CHARS_PER_GROUP":{"_errors":["expected number, received undefined"]}}
```

## Root cause

`daily-digest.yml` passes every config value as `${{ vars.X }}`. GitHub Actions interpolates an **unset** repo variable to an **empty string**, so the env var is *present-but-empty* rather than `undefined`. Zod's `.default()` only fires on `undefined`, so `""` bypassed the default; `toNum("")` returned `undefined` and the inner `z.number()` rejected it and threw.

`MAX_INPUT_CHARS_PER_GROUP` had no repo variable set (recently added to code/README but never created in repo settings), so it hit this path. The other numeric vars survived only because their repo variables happen to be set — i.e. the code `.default()`s were effectively dead in the Actions path.

## Fix

- Move `.default()` **inside** the `preprocess` for every defaulted field, so `toStr`/`toNum`/`toBool` first normalize `""` → `undefined` and the default then applies.
- Route `LOG_LEVEL` through `toStr` for the same reason (previously `""` was accepted verbatim instead of defaulting to `info`).
- Add a regression test asserting empty-string env vars resolve to the code defaults — the exact production failure mode (existing tests only covered *unset*, not empty-string).

## Also done out-of-band

Created the missing repo variable `MAX_INPUT_CHARS_PER_GROUP=100000` for parity with the rest of the config. This alone already unblocks `main`; this PR prevents recurrence for any future var wired into the workflow before its repo variable exists.

## Verification

- `npm run build` — clean
- `npm test` — 108/108 pass, including the new empty-string case

🤖 Generated with [Claude Code](https://claude.com/claude-code)