### PR TITLE
Release: promote importance-ranked digest to production (main)

### DIFF
--- a/src/DigestPipeline.ts
+++ b/src/DigestPipeline.ts
@@ -8,6 +8,29 @@ import { applyMessageFilters } from "./utils/filters";
 import { buildDigestBlocks, formatDigest } from "./utils/format";
 import { DigestItem } from "./core/schemas";
 
+export interface DigestEntry {
+    result: string | DigestItem;
+    messageCount: number;
+    key: string;
+}
+
+const IMPORTANCE_RANK = { high: 0, medium: 1, low: 2 } as const;
+
+// Deterministic ordering: importance first (missing importance ranks as
+// medium, plain strings last), then busier groups first, then group key.
+export function sortDigestEntries(entries: DigestEntry[]): DigestEntry[] {
+    const rankOf = (r: string | DigestItem): number =>
+        typeof r === "string" ? 3 : IMPORTANCE_RANK[r.importance ?? "medium"];
+
+    return [...entries].sort((a, b) => {
+        const ra = rankOf(a.result);
+        const rb = rankOf(b.result);
+        if (ra !== rb) return ra - rb;
+        if (a.messageCount !== b.messageCount) return b.messageCount - a.messageCount;
+        return a.key.localeCompare(b.key);
+    });
+}
+
 export class DigestPipeline {
     private sources: Source[] = [];
     private destinations: Destination[] = [];
@@ -68,7 +91,7 @@ export class DigestPipeline {
 
         logger.info(`Processing ${groups.size} conversation groups...`);
 
-        const summaries: (string | DigestItem)[] = [];
+        const entries: DigestEntry[] = [];
 
         // 3. Process (Summarize)
         for (const [key, messages] of groups) {
@@ -82,26 +105,38 @@ export class DigestPipeline {
             try {
                 const result = await this.processor.process(filtered);
                 if (typeof result === 'string') {
-                    if (result.trim()) summaries.push(result);
+                    if (result.trim()) entries.push({ result, messageCount: filtered.length, key });
                 } else {
-                    summaries.push(result);
+                    entries.push({ result, messageCount: filtered.length, key });
                 }
             } catch (err: any) {
                 logger.error(`Failed to process group ${key}: ${err.message}`);
             }
         }
 
-        if (summaries.length === 0) {
+        if (entries.length === 0) {
             logger.info("No summaries generated.");
             return;
         }
 
+        // Rank groups by importance before formatting so blocks and fallback
+        // text agree on ordering.
+        const summaries = sortDigestEntries(entries).map(e => e.result);
+
         // 4. Format & Send
-        // Generate fallback text by converting items to markdown
-        const combinedSummary = summaries.map(s => {
+        // Generate fallback text by converting items to markdown; low-importance
+        // items collapse into a single links line, mirroring the block rendering.
+        const mainItems = summaries.filter(s => typeof s === 'string' || s.importance !== 'low');
+        const lowItems = summaries.filter((s): s is DigestItem => typeof s !== 'string' && s.importance === 'low');
+
+        const fallbackParts = mainItems.map(s => {
             if (typeof s === 'string') return s;
             return `## [${s.headline}](${s.url})\n\n${s.summary}`;
-        }).join("\n\n");
+        });
+        if (lowItems.length > 0) {
+            fallbackParts.push(`Also active: ${lowItems.map(s => `[${s.headline}](${s.url})`).join(", ")}`);
+        }
+        const combinedSummary = fallbackParts.join("\n\n");
 
         const blockSets = buildDigestBlocks({
             items: summaries,

--- a/src/core/schemas.ts
+++ b/src/core/schemas.ts
@@ -1,10 +1,30 @@
 // src/core/schemas.ts
 import { z } from "zod";
 
+export const ImportanceSchema = z.enum(["high", "medium", "low"]);
+
+export type Importance = z.infer<typeof ImportanceSchema>;
+
+// Shape requested from the LLM. URLs are never requested from the model;
+// per-conversation links are resolved from firstMessageIndex by the processor.
+export const LlmSummarySchema = z.object({
+    headline: z.string().describe("The channel name or topic title, exactly as given in the prompt CONTEXT line"),
+    importance: ImportanceSchema.describe("Overall importance of this conversation group per the IMPORTANCE RATING rubric in the prompt"),
+    topics: z.array(z.object({
+        title: z.string().describe("Short label for this distinct conversation, max ~8 words"),
+        firstMessageIndex: z.number().int().describe("The [i] number of the message where this conversation started"),
+        summary: z.string().describe("1-3 one-sentence markdown bullets covering the key points, decisions, and action items, attributing statements to participants by name"),
+    })).describe("Distinct conversations found in the messages, most important first"),
+});
+
+export type LlmSummary = z.infer<typeof LlmSummarySchema>;
+
+// Downstream contract consumed by the pipeline and formatters.
 export const DigestItemSchema = z.object({
     headline: z.string().describe("The channel name or topic title, exactly as given in the prompt CONTEXT line"),
     url: z.string().describe("The URL to the source context, exactly as given in the prompt URL line"),
     summary: z.string().describe("Concise markdown bullets covering the key discussion points, decisions, and action items, attributing statements to participants by name"),
+    importance: ImportanceSchema.optional(),
 });
 
 export type DigestItem = z.infer<typeof DigestItemSchema>;

--- a/src/services/llm/AiSdkProcessor.ts
+++ b/src/services/llm/AiSdkProcessor.ts
@@ -101,8 +101,8 @@ export class AiSdkProcessor implements Processor {
         parts.push("IMPORTANCE RATING:");
         parts.push("Classify this conversation group's overall importance as exactly one of \"high\", \"medium\", or \"low\":");
         parts.push("- high: security vulnerabilities or incidents; outages or urgent operational issues; releases, network upgrades, or breaking changes that require users to act; major governance proposals or votes that are currently open");
-        parts.push("- medium: substantive technical or development discussion; grant applications and funding discussions with active back-and-forth; roadmap/planning; notable community or user feedback; ecosystem and adoption news");
-        parts.push("- low: routine procedural announcements (e.g. a grant decision notice with little or no discussion); casual chatter; greetings; quick support Q&A; memes; off-topic conversation");
+        parts.push("- medium: substantive technical or development discussion; grant approvals and funding awards; grant applications and funding discussions with active back-and-forth; roadmap/planning; notable community or user feedback; ecosystem and adoption news");
+        parts.push("- low: routine procedural announcements, including grant rejections or decisions not to advance a proposal; casual chatter; greetings; quick support Q&A; memes; off-topic conversation");
         parts.push("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
         parts.push("");
         parts.push("FORMATTING RULES:");

--- a/src/services/llm/AiSdkProcessor.ts
+++ b/src/services/llm/AiSdkProcessor.ts
@@ -164,20 +164,23 @@ export class AiSdkProcessor implements Processor {
             // topics, linking each title to the real URL of its first message.
             // Indices reference the same post-truncation array used to number
             // the prompt; anything out of range degrades to an unlinked title.
+            // Titles are emitted as Slack links directly (not markdown) and
+            // sanitized so model-controlled text can't alter link structure.
             const summary = parsed.data.topics.map(t => {
                 const idx = t.firstMessageIndex;
                 const url = Number.isInteger(idx) && idx >= 1 && idx <= truncated.length
                     ? truncated[idx - 1].url
                     : undefined;
-                const title = url ? `[${t.title}](${url})` : t.title;
+                const title = this.sanitizeLinkText(t.title);
+                const linkedTitle = url ? `<${url}|${title}>` : title;
                 // The model occasionally emits literal backslash-n sequences
                 // inside the JSON string; render them as real newlines.
                 const body = t.summary.replace(/\\n/g, "\n");
-                return `- *${title}*\n${body}`;
+                return `- *${linkedTitle}*\n${body}`;
             }).join("\n");
 
             return {
-                headline: parsed.data.headline || defaultHeadline,
+                headline: this.sanitizeLinkText(parsed.data.headline || defaultHeadline),
                 url: groupUrl,
                 summary,
                 importance: parsed.data.importance
@@ -192,6 +195,18 @@ export class AiSdkProcessor implements Processor {
                 importance: "medium"
             };
         }
+    }
+
+    // Model-controlled text rendered inside Slack links (<url|text>) or bold
+    // markers must not carry mrkdwn-reserved or link-structure characters:
+    // escape &, <, > per Slack's rules and drop []()| outright.
+    private sanitizeLinkText(text: string): string {
+        return text
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/[\[\]()|]/g, "")
+            .trim();
     }
 
     private formatMessageLine(msg: NormalizedMessage): string {

--- a/src/services/llm/AiSdkProcessor.ts
+++ b/src/services/llm/AiSdkProcessor.ts
@@ -6,7 +6,7 @@ import { Processor } from "../../core/interfaces";
 import { NormalizedMessage } from "../../core/types";
 import { Config } from "../../config";
 import { logger } from "../../utils/logger";
-import { DigestItem, DigestItemSchema } from "../../core/schemas";
+import { DigestItem, LlmSummarySchema } from "../../core/schemas";
 
 export class AiSdkProcessor implements Processor {
     name = "ai-sdk-google";
@@ -68,7 +68,7 @@ export class AiSdkProcessor implements Processor {
         }
 
         const prompt = parts.join("\n");
-        return this.generate(prompt, `#${channelName}`, realChannelUrl);
+        return this.generate(prompt, `#${channelName}`, realChannelUrl, truncated);
     }
 
     private async summarizeDiscourse(messages: NormalizedMessage[]): Promise<DigestItem> {
@@ -93,16 +93,25 @@ export class AiSdkProcessor implements Processor {
         }
 
         const prompt = parts.join("\n");
-        return this.generate(prompt, topicTitle, topicUrl);
+        return this.generate(prompt, topicTitle, topicUrl, truncated);
     }
 
     // Rules shared by both prompt builders.
     private pushSharedRules(parts: string[]): void {
+        parts.push("IMPORTANCE RATING:");
+        parts.push("Classify this conversation group's overall importance as exactly one of \"high\", \"medium\", or \"low\":");
+        parts.push("- high: security vulnerabilities or incidents; outages or urgent operational issues; releases, network upgrades, or breaking changes that require users to act; major governance proposals or votes that are currently open");
+        parts.push("- medium: substantive technical or development discussion; grant applications and funding discussions with active back-and-forth; roadmap/planning; notable community or user feedback; ecosystem and adoption news");
+        parts.push("- low: routine procedural announcements (e.g. a grant decision notice with little or no discussion); casual chatter; greetings; quick support Q&A; memes; off-topic conversation");
+        parts.push("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
+        parts.push("");
         parts.push("FORMATTING RULES:");
-        parts.push("- Identify important conversations naturally (security, funding, governance, performance, adoption, community feedback, etc.)");
-        parts.push("- For each significant topic, provide concise bullets");
+        parts.push("- Be brief. At most 5 bullets for high importance, 3 for medium, 2 for low; one sentence per bullet, max ~25 words.");
+        parts.push("- Put each bullet on its own line, starting with \"- \".");
+        parts.push("- For each distinct conversation, set firstMessageIndex to the [i] number of the message that started it.");
+        parts.push("- Conversation titles must describe the specific discussion; do not repeat the channel or topic name.");
         parts.push("- Include participant names inline for significant discussions (e.g., 'Alice and Bob discussed X')");
-        parts.push("- If there are decisions, action items, or shared links, label those sections");
+        parts.push("- If there are explicit decisions or action items, prefix those bullets \"Decision:\" or \"Action:\"");
         parts.push("- Do NOT output acknowledgements, confirmations, or meta-commentary");
         parts.push("");
         parts.push("ACCURACY RULES:");
@@ -111,7 +120,7 @@ export class AiSdkProcessor implements Processor {
         parts.push("");
     }
 
-    private async generate(prompt: string, defaultHeadline: string, defaultUrl: string): Promise<DigestItem> {
+    private async generate(prompt: string, defaultHeadline: string, groupUrl: string, truncated: NormalizedMessage[]): Promise<DigestItem> {
         try {
             const model = this.google(this.config.GEMINI_MODEL);
             const { object } = await pRetry(
@@ -119,7 +128,7 @@ export class AiSdkProcessor implements Processor {
                     try {
                         return await generateObject({
                             model,
-                            schema: DigestItemSchema as any,
+                            schema: LlmSummarySchema as any,
                             prompt,
                             maxOutputTokens: this.config.MAX_SUMMARY_TOKENS,
                         });
@@ -141,30 +150,46 @@ export class AiSdkProcessor implements Processor {
                 }
             );
 
-            const parsed = DigestItemSchema.safeParse(object);
+            const parsed = LlmSummarySchema.safeParse(object);
             if (!parsed.success) {
                 return {
                     headline: defaultHeadline,
-                    url: defaultUrl,
-                    summary: "Error generating summary."
+                    url: groupUrl,
+                    summary: "Error generating summary.",
+                    importance: "medium"
                 };
             }
 
-            // Fallback if model hallucinates empty fields, though schema enforces strings.
-            return {
-                headline: parsed.data.headline || defaultHeadline,
-                url: parsed.data.url || defaultUrl,
+            // Compose the digest summary from the model's per-conversation
+            // topics, linking each title to the real URL of its first message.
+            // Indices reference the same post-truncation array used to number
+            // the prompt; anything out of range degrades to an unlinked title.
+            const summary = parsed.data.topics.map(t => {
+                const idx = t.firstMessageIndex;
+                const url = Number.isInteger(idx) && idx >= 1 && idx <= truncated.length
+                    ? truncated[idx - 1].url
+                    : undefined;
+                const title = url ? `[${t.title}](${url})` : t.title;
                 // The model occasionally emits literal backslash-n sequences
                 // inside the JSON string; render them as real newlines.
-                summary: parsed.data.summary.replace(/\\n/g, "\n")
+                const body = t.summary.replace(/\\n/g, "\n");
+                return `- *${title}*\n${body}`;
+            }).join("\n");
+
+            return {
+                headline: parsed.data.headline || defaultHeadline,
+                url: groupUrl,
+                summary,
+                importance: parsed.data.importance
             };
         } catch (err: any) {
             logger.error(`AiSdk generation failed: ${err.message}`);
             // Return a fallback DigestItem
             return {
                 headline: defaultHeadline,
-                url: defaultUrl,
-                summary: "Error generating summary."
+                url: groupUrl,
+                summary: "Error generating summary.",
+                importance: "medium"
             };
         }
     }

--- a/src/services/slack/SlackDestination.ts
+++ b/src/services/slack/SlackDestination.ts
@@ -104,6 +104,8 @@ export class SlackDestination implements Destination {
                     channel: this.config.SLACK_CHANNEL_ID,
                     text: payload.text ?? "",
                     blocks: payload.blocks,
+                    unfurl_links: false,
+                    unfurl_media: false,
                 });
                 return;
             } catch (err: any) {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -47,10 +47,12 @@ export function buildDigestBlocks(params: {
 
   const range = `Time window: ${params.dateTitle} 00:00–${params.end.toISOString().slice(0, 10)} 00:00 UTC`;
 
+  const legend = "🔴 urgent · 🟡 notable · ⚪ routine";
+
   // Start with header blocks
   const headerBlocks: any[] = [
     { type: "header", text: { type: "plain_text", text: `Community Digest — ${params.dateTitle} (UTC)` } },
-    { type: "context", elements: [{ type: "mrkdwn", text: range }] },
+    { type: "context", elements: [{ type: "mrkdwn", text: range }, { type: "mrkdwn", text: legend }] },
     { type: "divider" },
   ];
 
@@ -60,20 +62,31 @@ export function buildDigestBlocks(params: {
   const allBlockSets: any[][] = [];
   let currentBlocks = [...headerBlocks];
 
-  for (let i = 0; i < params.items.length; i++) {
-    const item = params.items[i];
-    let sectionContent = "";
+  // Items arrive pre-sorted by importance. Low-importance items collapse
+  // into a single "Also active" links line instead of full sections.
+  const mainItems = params.items.filter(it => typeof it === 'string' || it.importance !== 'low');
+  const lowItems = params.items.filter((it): it is DigestItem => typeof it !== 'string' && it.importance === 'low');
 
+  const IMPORTANCE_MARKER: Record<string, string> = { high: "🔴 ", medium: "🟡 " };
+
+  const sections: string[] = [];
+  for (const item of mainItems) {
     if (typeof item === 'string') {
-      sectionContent = normalizeToSlackMrkdwn(item);
+      sections.push(normalizeToSlackMrkdwn(item));
     } else {
-      const header = `*<${item.url}|${item.headline}>*`;
+      const marker = item.importance ? IMPORTANCE_MARKER[item.importance] || "" : "";
+      const header = `${marker}*<${item.url}|${item.headline}>*`;
       const body = normalizeToSlackMrkdwn(item.summary);
-      sectionContent = `${header}\n\n${body}`;
+      sections.push(`${header}\n\n${body}`);
     }
+  }
+  if (lowItems.length > 0) {
+    sections.push(`⚪ *Also active:* ${lowItems.map(it => `<${it.url}|${it.headline}>`).join(", ")}`);
+  }
 
+  for (let i = 0; i < sections.length; i++) {
     // Create section block for this topic (truncate if needed)
-    const sectionText = truncateSection(sectionContent, MAX_SECTION_CHARS);
+    const sectionText = truncateSection(sections[i], MAX_SECTION_CHARS);
 
     if (!sectionText) continue;
 
@@ -87,7 +100,7 @@ export function buildDigestBlocks(params: {
       allBlockSets.push(currentBlocks);
       currentBlocks = [
         { type: "header", text: { type: "plain_text", text: `Community Digest — ${params.dateTitle} (UTC) [continued]` } },
-        { type: "context", elements: [{ type: "mrkdwn", text: range }] },
+        { type: "context", elements: [{ type: "mrkdwn", text: range }, { type: "mrkdwn", text: legend }] },
         { type: "divider" },
       ];
     }
@@ -96,7 +109,7 @@ export function buildDigestBlocks(params: {
     currentBlocks.push(topicBlock);
 
     // Add divider between topics (but not after the last one in a set)
-    if (i < params.items.length - 1) {
+    if (i < sections.length - 1) {
       currentBlocks.push({ type: "divider" });
     }
   }

--- a/test/integration/slack.test.ts
+++ b/test/integration/slack.test.ts
@@ -62,6 +62,8 @@ describe('SlackDestination Integration', () => {
             channel: 'C12345',
             text: 'summary',
             blocks: expect.anything(),
+            unfurl_links: false,
+            unfurl_media: false,
         });
     });
 

--- a/test/unit/AiSdkProcessor.test.ts
+++ b/test/unit/AiSdkProcessor.test.ts
@@ -47,8 +47,10 @@ describe("AiSdkProcessor", () => {
         mockGenerateObject.mockResolvedValue({
             object: {
                 headline: "Generated Headline",
-                url: "https://generated.url",
-                summary: "Generated Summary"
+                importance: "medium",
+                topics: [
+                    { title: "Topic A", firstMessageIndex: 1, summary: "- Generated Summary" },
+                ],
             }
         });
 
@@ -77,10 +79,13 @@ describe("AiSdkProcessor", () => {
 
         expect(mockGoogleModel).toHaveBeenCalledWith("gemini-1.5-pro");
         expect(mockGenerateObject).toHaveBeenCalled();
-        expect(result.headline).toBe("Generated Headline"); // Or check if it falls back to default if mocked return is empty?
-        // The mock returns "Generated Headline", so we expect that.
-        // Actually, the code uses `object.headline || defaultHeadline`.
-        expect(result.summary).toBe("Generated Summary");
+        expect(result.headline).toBe("Generated Headline");
+        expect(result.importance).toBe("medium");
+        // Topic title links to the first message of the conversation.
+        expect(result.summary).toContain("[Topic A](https://discord.com/channels/123/456/789)");
+        expect(result.summary).toContain("Generated Summary");
+        // Group URL is derived from the messages, never taken from the model.
+        expect(result.url).toBe("https://discord.com/channels/123/456");
     });
 
     it("should process Discourse messages", async () => {
@@ -100,7 +105,8 @@ describe("AiSdkProcessor", () => {
 
         expect(mockGenerateObject).toHaveBeenCalled();
         expect(result.headline).toBe("Generated Headline");
-        expect(result.summary).toBe("Generated Summary");
+        expect(result.summary).toContain("Generated Summary");
+        expect(result.url).toBe("https://forum.example.com/t/topic-slug/123");
     });
 
     it("should handle empty messages", async () => {
@@ -130,6 +136,7 @@ describe("AiSdkProcessor", () => {
             const result = await promise;
 
             expect(result.summary).toContain("Error generating summary");
+            expect(result.importance).toBe("medium"); // failed groups aren't buried
             expect(mockGenerateObject).toHaveBeenCalledTimes(4); // 1 attempt + 3 retries
         } finally {
             vi.useRealTimers();
@@ -142,7 +149,11 @@ describe("AiSdkProcessor", () => {
             mockGenerateObject
                 .mockRejectedValueOnce(new Error("503 overloaded"))
                 .mockResolvedValueOnce({
-                    object: { headline: "H", url: "U", summary: "Recovered" },
+                    object: {
+                        headline: "H",
+                        importance: "low",
+                        topics: [{ title: "T", firstMessageIndex: 1, summary: "Recovered" }],
+                    },
                 });
 
             const messages: NormalizedMessage[] = [
@@ -153,7 +164,8 @@ describe("AiSdkProcessor", () => {
             await vi.runAllTimersAsync();
             const result = await promise;
 
-            expect(result.summary).toBe("Recovered");
+            expect(result.summary).toContain("Recovered");
+            expect(result.importance).toBe("low");
             expect(mockGenerateObject).toHaveBeenCalledTimes(2);
         } finally {
             vi.useRealTimers();
@@ -193,5 +205,88 @@ describe("AiSdkProcessor", () => {
         expect(prompt).not.toContain("OLDEST ");
         // Kept messages must still read oldest-first.
         expect(prompt.indexOf("MIDDLE")).toBeLessThan(prompt.indexOf("NEWEST"));
+    });
+
+    it("should include the importance rubric and brevity rules in the prompt", async () => {
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        await processor.process(messages);
+
+        const prompt: string = mockGenerateObject.mock.calls[0][0].prompt;
+        expect(prompt).toContain("IMPORTANCE RATING:");
+        expect(prompt).toContain("- high: security vulnerabilities");
+        expect(prompt).toContain("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
+        expect(prompt).toContain("Be brief. At most 5 bullets for high importance");
+        expect(prompt).toContain("set firstMessageIndex to the [i] number");
+        // Calibration: grants are medium by default, procedural notices low.
+        expect(prompt).toContain("- medium: substantive technical or development discussion; grant applications and funding discussions");
+        expect(prompt).toContain("- low: routine procedural announcements");
+        // Rendering hygiene rules.
+        expect(prompt).toContain("Put each bullet on its own line");
+        expect(prompt).toContain("do not repeat the channel or topic name");
+    });
+
+    it("should map firstMessageIndex to the real message URL", async () => {
+        mockGenerateObject.mockResolvedValue({
+            object: {
+                headline: "H",
+                importance: "high",
+                topics: [
+                    { title: "First convo", firstMessageIndex: 1, summary: "- bullet one" },
+                    { title: "Second convo", firstMessageIndex: 2, summary: "- bullet two" },
+                ],
+            }
+        });
+
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Starts convo one", createdAt: "2026-07-21T10:00:00.000Z", url: "https://discord.com/channels/123/456/111", channelId: "456", channelName: "general" },
+            { id: "2", source: "discord", author: "B", content: "Starts convo two", createdAt: "2026-07-21T11:00:00.000Z", url: "https://discord.com/channels/123/456/222", channelId: "456", channelName: "general" },
+        ];
+
+        const result = await processor.process(messages) as DigestItem;
+
+        expect(result.importance).toBe("high");
+        expect(result.summary).toContain("[First convo](https://discord.com/channels/123/456/111)");
+        expect(result.summary).toContain("[Second convo](https://discord.com/channels/123/456/222)");
+    });
+
+    it("should render an unlinked title when firstMessageIndex is out of range", async () => {
+        mockGenerateObject.mockResolvedValue({
+            object: {
+                headline: "H",
+                importance: "medium",
+                topics: [
+                    { title: "Hallucinated convo", firstMessageIndex: 99, summary: "- bullet" },
+                ],
+            }
+        });
+
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        const result = await processor.process(messages) as DigestItem;
+
+        expect(result.summary).toContain("*Hallucinated convo*");
+        expect(result.summary).not.toContain("[Hallucinated convo](");
+    });
+
+    it("should return a medium-importance fallback when the model output fails validation", async () => {
+        // Old shape: no importance/topics — must fail LlmSummarySchema.
+        mockGenerateObject.mockResolvedValue({
+            object: { headline: "H", url: "U", summary: "S" }
+        });
+
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        const result = await processor.process(messages) as DigestItem;
+
+        expect(result.summary).toContain("Error generating summary");
+        expect(result.importance).toBe("medium");
+        expect(result.url).toBe("https://discord.com/channels/123/456");
     });
 });

--- a/test/unit/AiSdkProcessor.test.ts
+++ b/test/unit/AiSdkProcessor.test.ts
@@ -82,7 +82,7 @@ describe("AiSdkProcessor", () => {
         expect(result.headline).toBe("Generated Headline");
         expect(result.importance).toBe("medium");
         // Topic title links to the first message of the conversation.
-        expect(result.summary).toContain("[Topic A](https://discord.com/channels/123/456/789)");
+        expect(result.summary).toContain("<https://discord.com/channels/123/456/789|Topic A>");
         expect(result.summary).toContain("Generated Summary");
         // Group URL is derived from the messages, never taken from the model.
         expect(result.url).toBe("https://discord.com/channels/123/456");
@@ -248,8 +248,8 @@ describe("AiSdkProcessor", () => {
         const result = await processor.process(messages) as DigestItem;
 
         expect(result.importance).toBe("high");
-        expect(result.summary).toContain("[First convo](https://discord.com/channels/123/456/111)");
-        expect(result.summary).toContain("[Second convo](https://discord.com/channels/123/456/222)");
+        expect(result.summary).toContain("<https://discord.com/channels/123/456/111|First convo>");
+        expect(result.summary).toContain("<https://discord.com/channels/123/456/222|Second convo>");
     });
 
     it("should render an unlinked title when firstMessageIndex is out of range", async () => {
@@ -270,7 +270,34 @@ describe("AiSdkProcessor", () => {
         const result = await processor.process(messages) as DigestItem;
 
         expect(result.summary).toContain("*Hallucinated convo*");
-        expect(result.summary).not.toContain("[Hallucinated convo](");
+        expect(result.summary).not.toContain("|Hallucinated convo>");
+    });
+
+    it("should sanitize model-controlled titles and headlines so they cannot alter link structure", async () => {
+        mockGenerateObject.mockResolvedValue({
+            object: {
+                headline: "Chan <script> & | stuff",
+                importance: "medium",
+                topics: [
+                    { title: "evil](https://evil.com) [x", firstMessageIndex: 1, summary: "- bullet" },
+                    { title: "pipe|and<angle>&amp", firstMessageIndex: 1, summary: "- bullet" },
+                ],
+            }
+        });
+
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        const result = await processor.process(messages) as DigestItem;
+
+        // Injected markdown/mrkdwn link syntax is neutralized; only the real URL appears.
+        expect(result.summary).not.toContain("evil.com)");
+        expect(result.summary).not.toContain("](");
+        expect(result.summary).toContain("<https://discord.com/channels/123/456/789|evilhttps://evil.com x>");
+        // Slack-reserved characters are escaped, structure characters dropped.
+        expect(result.summary).toContain("|pipeand&lt;angle&gt;&amp;amp>");
+        expect(result.headline).toBe("Chan &lt;script&gt; &amp;  stuff");
     });
 
     it("should return a medium-importance fallback when the model output fails validation", async () => {

--- a/test/unit/AiSdkProcessor.test.ts
+++ b/test/unit/AiSdkProcessor.test.ts
@@ -220,9 +220,9 @@ describe("AiSdkProcessor", () => {
         expect(prompt).toContain("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
         expect(prompt).toContain("Be brief. At most 5 bullets for high importance");
         expect(prompt).toContain("set firstMessageIndex to the [i] number");
-        // Calibration: grants are medium by default, procedural notices low.
-        expect(prompt).toContain("- medium: substantive technical or development discussion; grant applications and funding discussions");
-        expect(prompt).toContain("- low: routine procedural announcements");
+        // Calibration: grant approvals are notable (medium); rejections are routine (low).
+        expect(prompt).toContain("- medium: substantive technical or development discussion; grant approvals and funding awards");
+        expect(prompt).toContain("- low: routine procedural announcements, including grant rejections");
         // Rendering hygiene rules.
         expect(prompt).toContain("Put each bullet on its own line");
         expect(prompt).toContain("do not repeat the channel or topic name");

--- a/test/unit/digest_pipeline.test.ts
+++ b/test/unit/digest_pipeline.test.ts
@@ -1,9 +1,10 @@
 // test/unit/digest_pipeline.test.ts
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { DigestPipeline } from "../../src/DigestPipeline";
+import { DigestPipeline, DigestEntry, sortDigestEntries } from "../../src/DigestPipeline";
 import { Source, Destination, Processor } from "../../src/core/interfaces";
 import { Config } from "../../src/config";
 import { NormalizedMessage } from "../../src/core/types";
+import { DigestItem } from "../../src/core/schemas";
 
 describe("DigestPipeline", () => {
     let config: Config;
@@ -97,5 +98,117 @@ describe("DigestPipeline", () => {
         expect(mockSource.fetchMessages).toHaveBeenCalled();
         expect(processor.process).not.toHaveBeenCalled();
         expect(mockDest.sendDigest).not.toHaveBeenCalled();
+    });
+
+    it("sorts groups by importance before sending", async () => {
+        const makeMessage = (id: string, channelId: string): NormalizedMessage => ({
+            id,
+            source: "discord",
+            channelId,
+            content: "valid message content",
+            author: "user",
+            createdAt: new Date().toISOString(),
+            url: `http://url/${channelId}`,
+        });
+
+        const itemsByChannel: Record<string, DigestItem> = {
+            chan1: { headline: "#casual", url: "http://url/chan1", summary: "chatter", importance: "low" },
+            chan2: { headline: "#security", url: "http://url/chan2", summary: "vuln report", importance: "high" },
+            chan3: { headline: "#dev", url: "http://url/chan3", summary: "refactor talk", importance: "medium" },
+        };
+
+        processor.process = vi.fn().mockImplementation(async (msgs: NormalizedMessage[]) =>
+            itemsByChannel[msgs[0].channelId!]
+        );
+
+        const mockSource: Source = {
+            name: "mock-source",
+            isEnabled: () => true,
+            fetchMessages: vi.fn().mockResolvedValue([
+                makeMessage("1", "chan1"),
+                makeMessage("2", "chan2"),
+                makeMessage("3", "chan3"),
+            ]),
+        };
+
+        const sent: any[][] = [];
+        const mockDest: Destination = {
+            name: "mock-dest",
+            isEnabled: () => true,
+            sendDigest: vi.fn().mockImplementation(async (blocks: any[]) => {
+                sent.push(blocks);
+            }),
+        };
+
+        pipeline.addSource(mockSource);
+        pipeline.addDestination(mockDest);
+
+        await pipeline.run();
+
+        expect(sent).toHaveLength(1);
+        const sectionTexts = sent[0]
+            .filter((b: any) => b.type === "section")
+            .map((b: any) => b.text.text);
+
+        // High before medium; low collapsed into a trailing "Also active" line.
+        const securityIdx = sectionTexts.findIndex((t: string) => t.includes("#security"));
+        const devIdx = sectionTexts.findIndex((t: string) => t.includes("#dev"));
+        const alsoActiveIdx = sectionTexts.findIndex((t: string) => t.includes("Also active"));
+        expect(securityIdx).toBeGreaterThanOrEqual(0);
+        expect(securityIdx).toBeLessThan(devIdx);
+        expect(devIdx).toBeLessThan(alsoActiveIdx);
+        expect(sectionTexts[alsoActiveIdx]).toContain("<http://url/chan1|#casual>");
+    });
+});
+
+describe("sortDigestEntries", () => {
+    const item = (importance: DigestItem["importance"]): DigestItem => ({
+        headline: "h",
+        url: "u",
+        summary: "s",
+        ...(importance ? { importance } : {}),
+    });
+
+    it("orders high before medium before low, with strings last", () => {
+        const entries: DigestEntry[] = [
+            { result: item("low"), messageCount: 1, key: "a" },
+            { result: "plain string", messageCount: 100, key: "b" },
+            { result: item("high"), messageCount: 1, key: "c" },
+            { result: item("medium"), messageCount: 1, key: "d" },
+        ];
+
+        const sorted = sortDigestEntries(entries);
+        expect(sorted.map(e => e.key)).toEqual(["c", "d", "a", "b"]);
+    });
+
+    it("treats missing importance as medium", () => {
+        const entries: DigestEntry[] = [
+            { result: item("low"), messageCount: 1, key: "a" },
+            { result: item(undefined), messageCount: 1, key: "b" },
+            { result: item("high"), messageCount: 1, key: "c" },
+        ];
+
+        const sorted = sortDigestEntries(entries);
+        expect(sorted.map(e => e.key)).toEqual(["c", "b", "a"]);
+    });
+
+    it("tiebreaks by message count desc, then key", () => {
+        const entries: DigestEntry[] = [
+            { result: item("medium"), messageCount: 2, key: "b" },
+            { result: item("medium"), messageCount: 5, key: "c" },
+            { result: item("medium"), messageCount: 2, key: "a" },
+        ];
+
+        const sorted = sortDigestEntries(entries);
+        expect(sorted.map(e => e.key)).toEqual(["c", "a", "b"]);
+    });
+
+    it("does not mutate the input array", () => {
+        const entries: DigestEntry[] = [
+            { result: item("low"), messageCount: 1, key: "a" },
+            { result: item("high"), messageCount: 1, key: "b" },
+        ];
+        sortDigestEntries(entries);
+        expect(entries.map(e => e.key)).toEqual(["a", "b"]);
     });
 });

--- a/test/unit/format.test.ts
+++ b/test/unit/format.test.ts
@@ -103,6 +103,7 @@ describe("buildDigestBlocks", () => {
     expect(blocks[0].text.text).toContain("Community Digest — 2025-08-27 (UTC)");
     expect(blocks[1].type).toBe("context");
     expect(blocks[1].elements[0].text).toContain("Time window: 2025-08-27 00:00–2025-08-28 00:00 UTC");
+    expect(blocks[1].elements[1].text).toBe("🔴 urgent · 🟡 notable · ⚪ routine");
     expect(blocks[2].type).toBe("divider");
     expect(blocks[3].type).toBe("section");
     expect(blocks[3].text.text).toContain("Some summary text");
@@ -124,5 +125,81 @@ describe("buildDigestBlocks", () => {
     expect(blocks[3].type).toBe("section");
     expect(blocks[3].text.text).toContain("*<https://discord.com/channels/123/456|My Channel>*");
     expect(blocks[3].text.text).toContain("Summary content");
+  });
+
+  it("prefixes importance markers on high and medium items", () => {
+    const blockSets = buildDigestBlocks({
+      items: [
+        { headline: "Security", url: "https://x/1", summary: "vuln", importance: "high" },
+        { headline: "Dev", url: "https://x/2", summary: "refactor", importance: "medium" },
+      ],
+      start: new Date("2025-08-27T00:00:00Z"),
+      end: new Date("2025-08-28T00:00:00Z"),
+      dateTitle: "2025-08-27",
+    });
+    const sections = blockSets[0].filter((b: any) => b.type === "section").map((b: any) => b.text.text);
+    expect(sections[0].startsWith("🔴 *<https://x/1|Security>*")).toBe(true);
+    expect(sections[1].startsWith("🟡 *<https://x/2|Dev>*")).toBe(true);
+  });
+
+  it("renders items without importance unchanged (no marker)", () => {
+    const blockSets = buildDigestBlocks({
+      items: [{ headline: "Plain", url: "https://x/1", summary: "text" }],
+      start: new Date("2025-08-27T00:00:00Z"),
+      end: new Date("2025-08-28T00:00:00Z"),
+      dateTitle: "2025-08-27",
+    });
+    const section = blockSets[0][3];
+    expect(section.text.text.startsWith("*<https://x/1|Plain>*")).toBe(true);
+  });
+
+  it("collapses low-importance items into a single 'Also active' section", () => {
+    const blockSets = buildDigestBlocks({
+      items: [
+        { headline: "Security", url: "https://x/1", summary: "vuln", importance: "high" },
+        { headline: "#casual", url: "https://x/2", summary: "chatter", importance: "low" },
+        { headline: "#random", url: "https://x/3", summary: "memes", importance: "low" },
+      ],
+      start: new Date("2025-08-27T00:00:00Z"),
+      end: new Date("2025-08-28T00:00:00Z"),
+      dateTitle: "2025-08-27",
+    });
+    const sections = blockSets[0].filter((b: any) => b.type === "section").map((b: any) => b.text.text);
+    expect(sections).toHaveLength(2);
+    expect(sections[1]).toContain("⚪ *Also active:*");
+    expect(sections[1]).toContain("<https://x/2|#casual>");
+    expect(sections[1]).toContain("<https://x/3|#random>");
+    // Low items must not get full sections.
+    expect(sections.some((t: string) => t.includes("chatter"))).toBe(false);
+  });
+
+  it("carries the legend into [continued] block sets", () => {
+    // Enough items to exceed the 45-block budget and force a split.
+    const items = Array.from({ length: 30 }, (_, i) => `Item ${i} content`);
+    const blockSets = buildDigestBlocks({
+      items,
+      start: new Date("2025-08-27T00:00:00Z"),
+      end: new Date("2025-08-28T00:00:00Z"),
+      dateTitle: "2025-08-27",
+    });
+    expect(blockSets.length).toBeGreaterThan(1);
+    for (const blocks of blockSets) {
+      expect(blocks[1].type).toBe("context");
+      expect(blocks[1].elements[1].text).toBe("🔴 urgent · 🟡 notable · ⚪ routine");
+    }
+  });
+
+  it("renders only the 'Also active' line when all items are low", () => {
+    const blockSets = buildDigestBlocks({
+      items: [
+        { headline: "#casual", url: "https://x/1", summary: "chatter", importance: "low" },
+      ],
+      start: new Date("2025-08-27T00:00:00Z"),
+      end: new Date("2025-08-28T00:00:00Z"),
+      dateTitle: "2025-08-27",
+    });
+    const sections = blockSets[0].filter((b: any) => b.type === "section").map((b: any) => b.text.text);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toContain("⚪ *Also active:* <https://x/1|#casual>");
   });
 });


### PR DESCRIPTION
## Why

The Daily Digest workflow runs on **`main`**, but the importance-ranking work (PR #37) was merged into **`dev`**, so it never reached production. Today's run (2026-07-23) succeeded but produced the *old* output — no legend, URLs still unfurled, no importance sorting/prioritization — because that code isn't on `main`.

This promotes `dev` → `main` (same path as PR #36) so the next digest run includes the new behavior.

## What lands on main

- `e32bb6d` feat: importance-ranked digest with conversation-start links
- `46d554e` fix: rubric distinguishes grant approvals (medium) from rejections (low)
- `d61fd31` fix: sanitize model-controlled link text (PR #37 review)
- `66262ce` Merge pull request #37 from alchemydc/feat/digest-importance-ranking

## Notes

- `main` already carries the config empty-string fix (PR #38, `d5d160c`); `dev` does not touch `src/config/index.ts`, so that fix is preserved by this merge. Verified clean via `git merge-tree` (no conflicts).
- After merge, the next scheduled run on `main` (13:00 UTC) will reflect the new digest format. `DRY_RUN=false` in prod, so any manual re-trigger posts a live digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)