### PR TITLE
ci: fix trigger branch names (develop→feat/fix, drop dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - Tests & Coverage
 
 on:
   push:
-    branches: [ main, develop, "feature/**" ]
+    branches: [ main, "feat/**", "fix/**" ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

CI push/PR triggers referenced `develop` and `feature/**`, which never matched this repo's actual branch names (`feat/**`; and the `dev` integration branch was never even listed). As a result the push-CI triggers effectively never fired on real working branches.

Now that `dev` is deleted and PRs target `main` directly, this aligns the triggers with reality.

## Change

```diff
   push:
-    branches: [ main, develop, "feature/**" ]
+    branches: [ main, "feat/**", "fix/**" ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
```

No job logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)