### PR TITLE
chore: ignore @types/node major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       - automated
     commit-message:
       prefix: "chore"
+    ignore:
+      # @types/node major must track the Node runtime (engines: ">=24 <25").
+      # Allow 24.x patch/minor; block the jump to 25.x. See commit 236691a.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Why

`@types/node` is intentionally pinned to `^24` to match the Node runtime (`engines.node: ">=24 <25"`, set in commit `236691a` — "align @types/node with runtime"). Dependabot kept proposing `@types/node` 25.x (closed PR #30), which would undo that alignment and keep coming back every week.

## Change

Add an `ignore` rule to the npm ecosystem block so `@types/node` semver-**major** bumps are skipped, while 24.x patch/minor updates still flow:

```yaml
    ignore:
      - dependency-name: "@types/node"
        update-types: ["version-update:semver-major"]
```

## Notes

- Revisit when the runtime moves to Node 25 (bump `engines` + drop this ignore).
- The other 5 open Dependabot PRs (#24, #25, #29, #32, #35) were closed as superseded — `main` already carries those versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)