### PR TITLE
ci: skip Codecov upload on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem
All Dependabot PRs (#42–#46) show a red `test` check. Every real CI step passes; the only failing step is **Upload coverage to Codecov**:

```
-> Token length: 0
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

GitHub does not expose repository Actions secrets to Dependabot-triggered workflow runs, so `CODECOV_TOKEN` is empty on those runs. With `fail_ci_if_error: true`, the tokenless upload fails the whole job — on every Dependabot PR.

## Fix
Guard the Codecov upload step with `if: github.actor != 'dependabot[bot]'`. Human pushes/PRs still upload coverage with fail-on-error; Dependabot PRs skip the upload. Coverage is still computed and retained via the existing coverage-artifact step (report-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)