### PR TITLE
feat: rate bug reports in maintained projects as urgent, not notable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ GEMINI_API_KEY=
 # Digest Config
 # DIGEST_WINDOW_HOURS=24
 
+# Triage
+# Comma-separated projects this org maintains; bug reports against them rate high.
+# MAINTAINED_PROJECTS=Zebra,zcashd,Zallet
+
 # Message Filters
 # MIN_MESSAGE_LENGTH=20
 # EXCLUDE_COMMANDS=true

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -48,4 +48,5 @@ jobs:
           MIN_MESSAGE_LENGTH: ${{ vars.MIN_MESSAGE_LENGTH }}
           EXCLUDE_COMMANDS: ${{ vars.EXCLUDE_COMMANDS }}
           EXCLUDE_LINK_ONLY: ${{ vars.EXCLUDE_LINK_ONLY }}
+          MAINTAINED_PROJECTS: ${{ vars.MAINTAINED_PROJECTS }}
         run: npm start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Other `AiSdkProcessor` behaviors worth knowing before editing it:
 - **Token budget:** Gemini 3.x reasoning tokens count against `maxOutputTokens` (`MAX_SUMMARY_TOKENS`), so the budget must leave headroom above the visible text or generation fails mid-JSON.
 - **Retry:** `p-retry` retries transient failures (429/5xx/network/parse) but `AbortError`s out of permanent `APICallError`s (auth/bad-request) so it doesn't burn retries.
 - **Truncation** (`truncateMessages`) keeps the **newest** messages when a group exceeds `MAX_INPUT_CHARS_PER_GROUP`, dropping the oldest.
-- The prompt's **importance rubric** (high/medium/low) is defined inline in `pushSharedRules()`.
+- The prompt's **importance rubric** (high/medium/low) is defined inline in `pushSharedRules()`. Its `high` tier is parameterized by `MAINTAINED_PROJECTS`: bug reports, regressions, and crashes in software this org maintains rate `high`, and the configured project names are interpolated into the rubric (the parenthetical is omitted when the variable is unset). The rubric also instructs the model to rate a group at its *most important* conversation rather than averaging — a single high-signal bug report in an otherwise routine thread must not be diluted to `medium`.
 
 ### Importance ranking
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Synapse is configured via environment variables.
 ### Destination
 - **Slack**: `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID`.
 
+### Triage
+- `MAINTAINED_PROJECTS`: Comma-separated names of the projects this organization maintains (e.g. `Zebra,zcashd,Zallet`). Optional. The importance rubric names these projects so bug reports, regressions, and crashes against them rate 🔴 `high` rather than 🟡 `medium`. Left unset, the rule still applies but the rubric says only "software this organization maintains".
+
 ## Scripts
 
 - `npm run dev`: Run in development mode with hot-reloading.

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -86,6 +86,7 @@ Required workflow variables (minimum):
 - `MIN_MESSAGE_LENGTH`
 - `EXCLUDE_COMMANDS`
 - `EXCLUDE_LINK_ONLY`
+- `MAINTAINED_PROJECTS` (optional; comma-separated, e.g. `Zebra,zcashd,Zallet`. Names the projects whose bug reports must rate `high` in the importance rubric.)
 
 ## 6) Operations: Daily Checks
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,6 +31,15 @@ const ConfigSchema = z.object({
   SLACK_CHANNEL_ID: z.preprocess(toStr, z.string()).optional(),
   GEMINI_API_KEY: z.preprocess(toStr, z.string()).optional(),
 
+  // Comma-separated names of the projects this organization maintains. Fed into
+  // the prompt's importance rubric so bug reports against our own software rate
+  // high. Optional: unset simply drops the parenthetical from the rubric.
+  // `.optional()` sits INSIDE the preprocess for the same reason `.default()`
+  // does above — an unset `${{ vars.MAINTAINED_PROJECTS }}` arrives as "", which
+  // toStr maps to undefined; an outer `.optional()` would be skipped and the
+  // inner z.string() would reject it.
+  MAINTAINED_PROJECTS: z.preprocess(toStr, z.string().optional()),
+
   // Defaults live inside the preprocess so they apply when an env var is
   // absent OR empty. In GitHub Actions an unset `${{ vars.X }}` interpolates
   // to "" (present, not undefined); toStr/toNum/toBool normalize "" to
@@ -112,6 +121,7 @@ export type Config = {
   SLACK_BOT_TOKEN?: string;
   SLACK_CHANNEL_ID?: string;
   GEMINI_API_KEY?: string;
+  MAINTAINED_PROJECTS: string[]; // parsed to array; may be empty
   GEMINI_MODEL: string;
   MAX_SUMMARY_TOKENS: number;
   MAX_INPUT_CHARS_PER_GROUP: number;
@@ -154,12 +164,14 @@ export function loadConfig(): Config {
   }
   const raw = parsed.data;
   const configBaseChannels = (raw.DISCORD_CHANNELS ?? "").split(",").map((id: string) => id.trim()).filter(Boolean);
+  const maintainedProjects = (raw.MAINTAINED_PROJECTS ?? "").split(",").map((p: string) => p.trim()).filter(Boolean);
 
   const discoBase = normalizeBaseUrl(raw.DISCOURSE_BASE_URL);
 
   const config: Config = {
     ...raw,
     DISCORD_CHANNELS: configBaseChannels,
+    MAINTAINED_PROJECTS: maintainedProjects,
     ENABLE_DISCORD: raw.ENABLE_DISCORD,
     ENABLE_DISCOURSE: raw.ENABLE_DISCOURSE,
 
@@ -191,6 +203,7 @@ export function loadConfig(): Config {
     minMessageLength: config.MIN_MESSAGE_LENGTH,
     excludeCommands: config.EXCLUDE_COMMANDS,
     excludeLinkOnly: config.EXCLUDE_LINK_ONLY,
+    maintainedProjectsCount: config.MAINTAINED_PROJECTS.length,
     enableFlags: {
       enableDiscord: raw.ENABLE_DISCORD,
       enableDiscourse: raw.ENABLE_DISCOURSE,

--- a/src/services/llm/AiSdkProcessor.ts
+++ b/src/services/llm/AiSdkProcessor.ts
@@ -96,14 +96,22 @@ export class AiSdkProcessor implements Processor {
         return this.generate(prompt, topicTitle, topicUrl, truncated);
     }
 
-    // Rules shared by both prompt builders.
+    // Rules shared by both prompt builders. The "our software" phrasing is
+    // parameterized by MAINTAINED_PROJECTS so the rubric can name the projects
+    // whose bug reports must rate high without hardcoding them here.
     private pushSharedRules(parts: string[]): void {
+        const projects = this.config.MAINTAINED_PROJECTS;
+        const ours = projects.length
+            ? `software this organization maintains (${projects.join(", ")})`
+            : "software this organization maintains";
+
         parts.push("IMPORTANCE RATING:");
         parts.push("Classify this conversation group's overall importance as exactly one of \"high\", \"medium\", or \"low\":");
-        parts.push("- high: security vulnerabilities or incidents; outages or urgent operational issues; releases, network upgrades, or breaking changes that require users to act; major governance proposals or votes that are currently open");
-        parts.push("- medium: substantive technical or development discussion; grant approvals and funding awards; grant applications and funding discussions with active back-and-forth; roadmap/planning; notable community or user feedback; ecosystem and adoption news");
+        parts.push(`- high: security vulnerabilities or incidents; bug reports, defects, regressions, crashes, or resource-exhaustion problems in ${ours}, including ones reported by node operators or users; outages or urgent operational issues; releases, network upgrades, or breaking changes that require users to act; major governance proposals or votes that are currently open`);
+        parts.push(`- medium: substantive technical or development discussion that is not a bug report in ${ours}; grant approvals and funding awards; grant applications and funding discussions with active back-and-forth; roadmap/planning; notable community or user feedback; ecosystem and adoption news`);
         parts.push("- low: routine procedural announcements, including grant rejections or decisions not to advance a proposal; casual chatter; greetings; quick support Q&A; memes; off-topic conversation");
-        parts.push("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
+        parts.push("Rate the group at the importance of its single most important conversation — do not average across the group. One high-importance report in an otherwise routine thread makes the whole group high.");
+        parts.push(`High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one, except for security issues and bug reports in ${ours}, which always rate high.`);
         parts.push("");
         parts.push("FORMATTING RULES:");
         parts.push("- Be brief. At most 5 bullets for high importance, 3 for medium, 2 for low; one sentence per bullet, max ~25 words.");

--- a/test/unit/AiSdkProcessor.test.ts
+++ b/test/unit/AiSdkProcessor.test.ts
@@ -31,6 +31,7 @@ describe("AiSdkProcessor", () => {
             MAX_INPUT_CHARS_PER_GROUP: 100000,
             // ... other required config props
             DISCORD_CHANNELS: [],
+            MAINTAINED_PROJECTS: [],
             DRY_RUN: true,
             DIGEST_WINDOW_HOURS: 24,
             LOG_LEVEL: "info",
@@ -217,15 +218,59 @@ describe("AiSdkProcessor", () => {
         const prompt: string = mockGenerateObject.mock.calls[0][0].prompt;
         expect(prompt).toContain("IMPORTANCE RATING:");
         expect(prompt).toContain("- high: security vulnerabilities");
-        expect(prompt).toContain("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one.");
+        expect(prompt).toContain("High should be rare — most groups are medium or low. When in doubt between two levels, choose the lower one, except for security issues and bug reports in software this organization maintains, which always rate high.");
         expect(prompt).toContain("Be brief. At most 5 bullets for high importance");
         expect(prompt).toContain("set firstMessageIndex to the [i] number");
         // Calibration: grant approvals are notable (medium); rejections are routine (low).
-        expect(prompt).toContain("- medium: substantive technical or development discussion; grant approvals and funding awards");
+        expect(prompt).toContain("grant approvals and funding awards");
         expect(prompt).toContain("- low: routine procedural announcements, including grant rejections");
         // Rendering hygiene rules.
         expect(prompt).toContain("Put each bullet on its own line");
         expect(prompt).toContain("do not repeat the channel or topic name");
+    });
+
+    it("rates a group by its most important conversation rather than averaging", async () => {
+        // A single high-signal bug report inside an otherwise routine thread was
+        // being diluted to medium because the rubric asked for "overall" importance.
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        await processor.process(messages);
+
+        const prompt: string = mockGenerateObject.mock.calls[0][0].prompt;
+        expect(prompt).toContain("Rate the group at the importance of its single most important conversation — do not average across the group.");
+        expect(prompt).toContain("One high-importance report in an otherwise routine thread makes the whole group high.");
+    });
+
+    it("names the maintained projects in the rubric when MAINTAINED_PROJECTS is set", async () => {
+        const scoped = new AiSdkProcessor({ ...config, MAINTAINED_PROJECTS: ["Zebra", "zcashd"] } as Config);
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discourse", author: "cartesien", content: "banned peer addr logged 300k times", createdAt: new Date().toISOString(), url: "https://forum.example.com/t/zebra-release/1/3", topicId: 1, topicTitle: "Zebra 6.2.3 release" },
+        ];
+
+        await scoped.process(messages);
+
+        const prompt: string = mockGenerateObject.mock.calls[0][0].prompt;
+        // Bug reports against our own software are high, not medium.
+        expect(prompt).toContain("bug reports, defects, regressions, crashes, or resource-exhaustion problems in software this organization maintains (Zebra, zcashd)");
+        // Medium is scoped so bug reports can't fall through to it.
+        expect(prompt).toContain("substantive technical or development discussion that is not a bug report in software this organization maintains (Zebra, zcashd)");
+        // The tie-break carve-out names them too.
+        expect(prompt).toContain("except for security issues and bug reports in software this organization maintains (Zebra, zcashd), which always rate high.");
+    });
+
+    it("omits the project parenthetical when MAINTAINED_PROJECTS is unset", async () => {
+        const messages: NormalizedMessage[] = [
+            { id: "1", source: "discord", author: "A", content: "Hello", createdAt: new Date().toISOString(), url: "https://discord.com/channels/123/456/789", channelId: "456", channelName: "general" },
+        ];
+
+        await processor.process(messages);
+
+        const prompt: string = mockGenerateObject.mock.calls[0][0].prompt;
+        expect(prompt).toContain("bug reports, defects, regressions, crashes, or resource-exhaustion problems in software this organization maintains, including");
+        // No empty parenthetical left behind.
+        expect(prompt).not.toContain("maintains ()");
     });
 
     it("should map firstMessageIndex to the real message URL", async () => {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -55,12 +55,14 @@ describe('Config Service', () => {
         process.env.EXCLUDE_LINK_ONLY = '';
         process.env.ENABLE_DISCORD = '';
         process.env.ENABLE_DISCOURSE = '';
+        process.env.MAINTAINED_PROJECTS = '';
 
         const config = loadConfig();
 
         expect(config.GEMINI_MODEL).toBe('gemini-3.6-flash');
         expect(config.MAX_SUMMARY_TOKENS).toBe(4000);
         expect(config.MAX_INPUT_CHARS_PER_GROUP).toBe(100000);
+        expect(config.MAINTAINED_PROJECTS).toEqual([]);
         expect(config.DRY_RUN).toBe(true);
         expect(config.DIGEST_WINDOW_HOURS).toBe(24);
         expect(config.LOG_LEVEL).toBe('info');
@@ -110,6 +112,14 @@ describe('Config Service', () => {
     it('should correctly parse number values', () => {
         process.env.MAX_SUMMARY_TOKENS = ' 1000 ';
         expect(loadConfig().MAX_SUMMARY_TOKENS).toBe(1000);
+    });
+
+    it('should parse MAINTAINED_PROJECTS into a trimmed list', () => {
+        process.env.MAINTAINED_PROJECTS = 'Zebra, zcashd ,,Zallet';
+        expect(loadConfig().MAINTAINED_PROJECTS).toEqual(['Zebra', 'zcashd', 'Zallet']);
+
+        delete process.env.MAINTAINED_PROJECTS;
+        expect(loadConfig().MAINTAINED_PROJECTS).toEqual([]);
     });
 
     it('should derive DISCORD_ENABLED correctly', () => {


### PR DESCRIPTION
## Why

A Zebra bug report on the community forum — [*Zebra 6.2.3 Release*, post #3](https://forum.zcashcommunity.com/t/zebra-6-2-3-release/56842/3): `"attempted to add a banned peer addr"` logged ~300k times in 24h, 61 MB/day of log bloat — was surfaced by the digest bot but labelled 🟡 **notable** (`medium`) instead of 🔴 **urgent** (`high`). Defect reports against software we maintain are exactly what the digest exists to escalate.

Three things in the rubric (`pushSharedRules()`) caused the miss:

1. **No such category existed.** `high` covered security vulns, outages, releases, and open governance votes. An operator-reported functional bug fit none of them, so `medium` was the model's best available answer. Nothing in the repo told the model which software is *ours* either — the Discourse adapter is fully generic.
2. **Group-level averaging.** `importance` is one value per topic group and the prompt asked for the group's *"overall"* importance. This was the *release* thread with the bug report as one reply among four, so the rating was diluted. (It also explains why a release thread — already `high` under the old rubric — came out `medium`.)
3. **A tie-break that fought any new rule:** *"When in doubt between two levels, choose the lower one."*

## What changed

Prompt steering plus one config variable. **No changes to the `Importance` enum, ranking, or Slack rendering.**

- **`MAINTAINED_PROJECTS`** (new, optional, comma-separated) — keeps project names out of `src/` so the Discourse adapter stays reusable. Parsed to `string[]` following the existing `DISCORD_CHANNELS` idiom.
- **Rubric** (`AiSdkProcessor.ts`) — `high` now covers *"bug reports, defects, regressions, crashes, or resource-exhaustion problems in software this organization maintains (…)"*; `medium` is scoped so bug reports can't fall through; a new line forbids averaging; the tie-break carves out security issues and our-software bug reports.
- Wired into `daily-digest.yml`, `.env.example`, `README.md`, the runbook, and the `AGENTS.md` rubric pointer.

## Verification

`npm run build` clean, `npm test` **112/112**. Also ran the real thread through the live model:

| Topic | Result |
|---|---|
| **Zebra 6.2.3 Release** | 🔴 **high** — was `medium` |
| Coinholder Retroactive Grants CFP | 🟡 medium |
| Welcome to the Zcash Forum | 🟡 medium |
| NU7 Token Holder Vote | 🔴 high (correct under the pre-existing governance rule) |

The Zebra thread now splits the bug report into its own linked conversation, crediting cartesien's report and nsheep's confirmation that a fix lands in v6.3.0. The lift is targeted, not blanket.

## Action required after merge

Set the **`MAINTAINED_PROJECTS` repo Variable** (e.g. `Zebra,zcashd,Zallet`). Without it the rule still fires but the rubric names no projects, which is weaker steering.

## Reviewer notes

- `MAINTAINED_PROJECTS` puts `.optional()` **inside** the `preprocess`. An unset `${{ vars.X }}` arrives as `""`, which `toStr` maps to `undefined`; an outer `.optional()` is skipped and the inner `z.string()` rejects it. This is the `.default()` gotcha already documented in `AGENTS.md` — it crashed `loadConfig()` during testing. Several **pre-existing** fields have the outer-`.optional()` shape and the same latent crash; tracked separately, not touched here.
- The perennial "Welcome to the Zcash Forum" thread came out `medium` rather than `low`. I did not A/B it against the old prompt, so I can't say whether the no-averaging line caused that or it was already `medium` — worth watching in the next real digest.
- CI may fail for reasons unrelated to this change; GitHub is having an outage as of opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)